### PR TITLE
Fix issue with multiple matchers being overridden with the latest one

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -177,16 +177,16 @@ class LinkifySettingTab extends PluginSettingTab {
 			new Setting(containerEl)
 				.setDesc("RegExp/Link")
 				.addText(text => {
-					text.setValue(rule.regexp)
+					text.setValue(this.plugin.settings.rules[index].regexp)
 					text.inputEl.onblur = async () => {
-						rule.regexp = text.getValue();
+						this.plugin.settings.rules[index].regexp = text.getValue();
 						await this.plugin.saveSettings();
 					};
 				})
 				.addText(text => {
-					text.setValue(rule.link);
+					text.setValue(this.plugin.settings.rules[index].link);
 					text.inputEl.onblur = async () => {
-						rule.link = text.getValue();
+						this.plugin.settings.rules[index].link = text.getValue();
 						await this.plugin.saveSettings();
 					};
 				})


### PR DESCRIPTION
I spotted this issue when attempting to add multiple matchers. It's difficult to spot why because I was only able to debug the compiled `main.js` file, but `rule` isn't always available when the `onblur()` triggers.

![image](https://user-images.githubusercontent.com/5631/175838347-3c1e7716-66d0-4729-907f-83c66c630a1b.png)

What I can't fully understand is why the `index` is available, but setting/getting the values directly from `this.plugin.settings.rules` with the index does seem to solve the issue.