### PR TITLE
Add an option to set a CSS class to be applied for each link type

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ For example, if the regular expression is `@(\w+)` and the link pattern is `http
 
 You can have multiple regex-link entries. Each one is applied independently.
 
+### Custom Styling For a Link Pattern
+By default, links will have the `linkified` CSS class applied to them. You can add additional classes based on the pattern by adding them to the "CSS Class" field.
+
 ### Delete a Link Pattern
 You can delete an entry by clicking on the trash can icon to the right of the entry.
 


### PR DESCRIPTION
Thanks for making this addon! I thought I'd add some functionality that I've been wanting. This does two things:

- Apply the `linkified` class to linkified links both in live preview and reading mode
- Add a field for a custom CSS class to be applied for each link pattern, defaulting to nothing.

The main point of this pull request is the last one, but I thought it was nicer/more convenient to apply the same class in both modes so that custom snippets can target both with one selector.