### PR TITLE
Fix #8: Allow internal links

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -102,7 +102,13 @@ export default class Linkify extends Plugin {
 			evt.target.className.includes("cm-link linkified")) {
 			let m = this.matchRule(evt.target.innerText);
 			if (m != null) {
-				window.open(m.link);
+				// try to match internal link
+				const internalLinkMatch = m.link.match(/^\[\[([^|\]]*)(?:\|[^|\]]*)?\]\]$/);
+				if (internalLinkMatch != null) {
+					this.app.workspace.openLinkText(internalLinkMatch.at(1), "");
+				} else {
+					window.open(m.link);
+				}
 			}
 		}
 	}
@@ -149,8 +155,7 @@ export default class Linkify extends Plugin {
 	// Converts matching text in the HTMLElement into links.
 	markdownPostProcessor(el: HTMLElement) {
 		if (el.firstChild instanceof Node) {
-			let walker = document.createTreeWalker(
-				el.firstChild, NodeFilter.SHOW_TEXT, null);
+			let walker = document.createTreeWalker(el.firstChild, NodeFilter.SHOW_TEXT, null);
 			let nodes: Node[] = [];
 			let node: Node;
 			while (node = walker.nextNode()) {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "linkify",
 	"version": "1.0.13",
 	"description": "Turns strings into links.",
-        "main": "main.js",
+	"main": "main.js",
 	"scripts": {
 		"dev": "node esbuild.config.mjs",
 		"build": "tsc -noEmit -skipLibCheck && node esbuild.config.mjs production",
@@ -12,13 +12,13 @@
 	"author": "",
 	"license": "MIT",
 	"devDependencies": {
-		"@types/node": "^16.11.6",
-		"@typescript-eslint/eslint-plugin": "^5.2.0",
-		"@typescript-eslint/parser": "^5.2.0",
-		"builtin-modules": "^3.2.0",
+		"@types/node": "^20.11.19",
+		"@typescript-eslint/eslint-plugin": "^7.0.2",
+		"@typescript-eslint/parser": "^7.0.2",
+		"builtin-modules": "^3.3.0",
 		"esbuild": "0.13.12",
 		"obsidian": "latest",
-		"tslib": "2.3.1",
-		"typescript": "4.4.4"
+		"tslib": "2.6.2",
+		"typescript": "5.3.3"
 	}
 }


### PR DESCRIPTION
@matthewhchan thank you for your awesome plugin!

This PR allows using internal links (e.g. [[test]]) in the plugin. As I needed the feature myself and saw that there also was an open issue asking for it, I decided to implement it.

While this was possible using the Obsidian URI-scheme `obsidian://open?file=$1`, I believe this is not very user friendly, as it is not obvious and you have to URI encode the destination file path. Now you can just enter an internal link as target.

Once a match is detected, we check if the target is an internal link, and if so we open the file directly in Obsidian. Otherwise we open the external link.

_Note: I also had to update some dependencies, because I was getting an error with codemirror types. I suggest commiting the lockfile to the repo._